### PR TITLE
Remove hardcoded factionIcon paths and dynamically load them at startup

### DIFF
--- a/Source/FactionColonies/FactionColonies.cs
+++ b/Source/FactionColonies/FactionColonies.cs
@@ -204,8 +204,8 @@ namespace FactionColonies
 			}
 			if (factionFC.updateVersion < 0.337)
 			{
-				factionFC.factionIcon = texLoad.factionIcons.First().Value;
-				factionFC.factionIconPath = texLoad.factionIcons.First().Key;
+				factionFC.factionIcon = texLoad.factionIcons.First();
+				factionFC.factionIconPath = texLoad.factionIcons.First().name;
 			}
 
 			if (factionFC.updateVersion < 0.339)

--- a/Source/FactionColonies/FactionFC.cs
+++ b/Source/FactionColonies/FactionFC.cs
@@ -43,8 +43,8 @@ namespace FactionColonies
         public Map taxMap;
         public TechLevel techLevel = TechLevel.Undefined;
         private bool firstTick = true;
-        public string factionIconPath = texLoad.factionIcons.ElementAt(0).Key;
-        public Texture2D factionIcon = texLoad.factionIcons.ElementAt(0).Value;
+        public Texture2D factionIcon = texLoad.factionIcons.ElementAt(0);
+        public string factionIconPath = texLoad.factionIcons.ElementAt(0).name;
 
 
         //New Types of PRoductions
@@ -1042,8 +1042,9 @@ namespace FactionColonies
                 if (FCf != null)
                 {
                     FCf.def.techLevel = TechLevel.Undefined;
-                    factionIcon = texLoad.factionIcons.Where(obj => obj.Key == factionIconPath).First().Value;
-                    updateFactionIcon(ref FCf, "FactionIcons/" + factionIconPath);
+                    factionIcon = texLoad.factionIcons.FirstOrFallback(obj => obj.name == factionIconPath, texLoad.factionIcons.First());
+                    updateFactionIcon(ref FCf, "FactionIcons/" + factionIcon.name);
+                    factionIconPath = factionIcon.name;
                 }
                 factionBackup = FCf;
 

--- a/Source/FactionColonies/factionCustomizeWindowFC.cs
+++ b/Source/FactionColonies/factionCustomizeWindowFC.cs
@@ -199,13 +199,13 @@ namespace FactionColonies
 			if(Widgets.ButtonImage(buttonIcon, tempFactionIcon))
 			{
 				List<FloatMenuOption> list = new List<FloatMenuOption>();
-				foreach (KeyValuePair<string, Texture2D> pair in texLoad.factionIcons)
+				foreach (Texture2D texture in texLoad.factionIcons)
 				{
-					list.Add(new FloatMenuOption(pair.Key, delegate
+					list.Add(new FloatMenuOption(texture.name, delegate
 					{
-						tempFactionIcon = pair.Value;
-						tempFactionIconPath = pair.Key;
-					}, pair.Value, Color.white));
+						tempFactionIcon = texture;
+						tempFactionIconPath = texture.name;
+					}, texture, Color.white));
 				}
 				FloatMenu menu = new FloatMenu(list);
 				Find.WindowStack.Add(menu);

--- a/Source/FactionColonies/texLoad.cs
+++ b/Source/FactionColonies/texLoad.cs
@@ -8,8 +8,18 @@ using Verse;
 namespace FactionColonies
 {
     [StaticConstructorOnStartup]
-    internal static class texLoad
+    public static class texLoad
     {
+        static texLoad()
+        {
+            var icons = ContentFinder<Texture2D>.GetAllInFolder("FactionIcons");
+            factionIcons = icons.ToList();
+            if (factionIcons.NullOrEmpty())
+            {
+                Log.Error("Empire - No faction icons found, will probably result in Empire not working properly.");
+            }
+        }
+
         public static readonly Texture2D iconTest100 = ContentFinder<Texture2D>.Get("GUI/100x");
         public static readonly Texture2D questionmark = ContentFinder<Texture2D>.Get("GUI/questionmark");
         public static readonly Texture2D buildingLocked = ContentFinder<Texture2D>.Get("GUI/LockedBuildingSlot");
@@ -67,41 +77,6 @@ namespace FactionColonies
                new KeyValuePair<string, Texture2D>("research", ContentFinder<Texture2D>.Get("GUI/ProductionResearch"))
         };
 
-        public static readonly List<KeyValuePair<string, Texture2D>> factionIcons = new List<KeyValuePair<string, Texture2D>>()
-        {
-            new KeyValuePair<string, Texture2D>("Balance", ContentFinder<Texture2D>.Get("FactionIcons/Balance")),
-            new KeyValuePair<string, Texture2D>("Assassin", ContentFinder<Texture2D>.Get("FactionIcons/Assassin")),
-            new KeyValuePair<string, Texture2D>("Flame", ContentFinder<Texture2D>.Get("FactionIcons/Flame")),
-            new KeyValuePair<string, Texture2D>("Fox_Girl", ContentFinder<Texture2D>.Get("FactionIcons/Fox_Girl")),
-            new KeyValuePair<string, Texture2D>("Imperial", ContentFinder<Texture2D>.Get("FactionIcons/Imperial")),
-            new KeyValuePair<string, Texture2D>("Lifted", ContentFinder<Texture2D>.Get("FactionIcons/Lifted")),
-            new KeyValuePair<string, Texture2D>("Lion", ContentFinder<Texture2D>.Get("FactionIcons/Lion")),
-            new KeyValuePair<string, Texture2D>("Pirate", ContentFinder<Texture2D>.Get("FactionIcons/Pirate")),
-            new KeyValuePair<string, Texture2D>("Royalty", ContentFinder<Texture2D>.Get("FactionIcons/Royalty")),
-            new KeyValuePair<string, Texture2D>("Spartan", ContentFinder<Texture2D>.Get("FactionIcons/Spartan")),
-            new KeyValuePair<string, Texture2D>("Thrumbohorn", ContentFinder<Texture2D>.Get("FactionIcons/Thrumbohorn")),
-            new KeyValuePair<string, Texture2D>("Western", ContentFinder<Texture2D>.Get("FactionIcons/Western")),
-
-            new KeyValuePair<string, Texture2D>("Base", ContentFinder<Texture2D>.Get("FactionIcons/Base")),
-            new KeyValuePair<string, Texture2D>("Blue_Phoenix", ContentFinder<Texture2D>.Get("FactionIcons/Blue_Phoenix")),
-            new KeyValuePair<string, Texture2D>("Boomalope", ContentFinder<Texture2D>.Get("FactionIcons/Boomalope")),
-            new KeyValuePair<string, Texture2D>("Communists", ContentFinder<Texture2D>.Get("FactionIcons/Communists")),
-            new KeyValuePair<string, Texture2D>("Dragon", ContentFinder<Texture2D>.Get("FactionIcons/Dragon")),
-            new KeyValuePair<string, Texture2D>("Kilroy", ContentFinder<Texture2D>.Get("FactionIcons/Kilroy")),
-            new KeyValuePair<string, Texture2D>("New_Star", ContentFinder<Texture2D>.Get("FactionIcons/New_Star")),
-            new KeyValuePair<string, Texture2D>("Old_Star", ContentFinder<Texture2D>.Get("FactionIcons/Old_Star")),
-            new KeyValuePair<string, Texture2D>("Pattern_1", ContentFinder<Texture2D>.Get("FactionIcons/Pattern_1")),
-            new KeyValuePair<string, Texture2D>("Pattern_2", ContentFinder<Texture2D>.Get("FactionIcons/Pattern_2")),
-            new KeyValuePair<string, Texture2D>("Pattern_3", ContentFinder<Texture2D>.Get("FactionIcons/Pattern_3")),
-            new KeyValuePair<string, Texture2D>("Pattern_4", ContentFinder<Texture2D>.Get("FactionIcons/Pattern_4")),
-            new KeyValuePair<string, Texture2D>("Prisoner", ContentFinder<Texture2D>.Get("FactionIcons/Prisoner")),
-            new KeyValuePair<string, Texture2D>("Red_Phoenix", ContentFinder<Texture2D>.Get("FactionIcons/Red_Phoenix")),
-            new KeyValuePair<string, Texture2D>("Royal_Owl", ContentFinder<Texture2D>.Get("FactionIcons/Royal_Owl")),
-            new KeyValuePair<string, Texture2D>("Slightly_Less_Royal_Owl", ContentFinder<Texture2D>.Get("FactionIcons/Slightly_Less_Royal_Owl")),
-            new KeyValuePair<string, Texture2D>("Thrumbo", ContentFinder<Texture2D>.Get("FactionIcons/Thrumbo")),
-            new KeyValuePair<string, Texture2D>("Wolf", ContentFinder<Texture2D>.Get("FactionIcons/Wolf"))
-        };
-
-
+        public static List<Texture2D> factionIcons = new List<Texture2D>();
     }
 }


### PR DESCRIPTION
This allows users to add their own icons by putting them in `Textures/FactionIcons`. Requires a game restart to reload the icons, couldn't find a nice solution to that. Compatible with existing saves.