### PR TITLE
Additional Reqs for Buildings/Events

### DIFF
--- a/Source/FactionColonies/defs/BuildingFC.cs
+++ b/Source/FactionColonies/defs/BuildingFC.cs
@@ -16,10 +16,7 @@ namespace FactionColonies
             Scribe_Values.Look(ref constructionDuration, "constructionDuration");
             Scribe_Collections.Look(ref traits, "traits", LookMode.Def);
             Scribe_Collections.Look(ref applicableBiomes, "applicableBiomes", LookMode.Value);
-			Scribe_Collections.Look(ref requiredPolicies, "requiredPolicies", LookMode.Value);
-			Scribe_Collections.Look(ref requiredPolicies, "requiredBuildings", LookMode.Value);
             Scribe_Values.Look(ref upkeep, "upkeep");
-            Scribe_Values.Look(ref unique, "unique");
             Scribe_Values.Look(ref iconPath, "iconPath");
         }
 
@@ -31,9 +28,6 @@ namespace FactionColonies
         public List<string> applicableBiomes = new List<string>();
         public int upkeep;
         public string iconPath = "GUI/unrest";
-		public bool unique;
-        public List<string> requiredPolicies = new List<string>();
-		public List<string> requiredBuildings= new List<string>();
         public Texture2D iconLoaded;
         //public required research
 

--- a/Source/FactionColonies/defs/BuildingFC.cs
+++ b/Source/FactionColonies/defs/BuildingFC.cs
@@ -16,7 +16,10 @@ namespace FactionColonies
             Scribe_Values.Look(ref constructionDuration, "constructionDuration");
             Scribe_Collections.Look(ref traits, "traits", LookMode.Def);
             Scribe_Collections.Look(ref applicableBiomes, "applicableBiomes", LookMode.Value);
+			Scribe_Collections.Look(ref requiredPolicies, "requiredPolicies", LookMode.Value);
+			Scribe_Collections.Look(ref requiredPolicies, "requiredBuildings", LookMode.Value);
             Scribe_Values.Look(ref upkeep, "upkeep");
+            Scribe_Values.Look(ref unique, "unique");
             Scribe_Values.Look(ref iconPath, "iconPath");
         }
 
@@ -28,6 +31,9 @@ namespace FactionColonies
         public List<string> applicableBiomes = new List<string>();
         public int upkeep;
         public string iconPath = "GUI/unrest";
+		public bool unique;
+        public List<string> requiredPolicies = new List<string>();
+		public List<string> requiredBuildings= new List<string>();
         public Texture2D iconLoaded;
         //public required research
 

--- a/Source/FactionColonies/defs/BuildingFC.cs
+++ b/Source/FactionColonies/defs/BuildingFC.cs
@@ -16,7 +16,10 @@ namespace FactionColonies
             Scribe_Values.Look(ref constructionDuration, "constructionDuration");
             Scribe_Collections.Look(ref traits, "traits", LookMode.Def);
             Scribe_Collections.Look(ref applicableBiomes, "applicableBiomes", LookMode.Value);
+			Scribe_Collections.Look(ref requiredPolicies, "requiredPolicies", LookMode.Value);
+			Scribe_Collections.Look(ref requiredBuildings, "requiredBuildings", LookMode.Value);
             Scribe_Values.Look(ref upkeep, "upkeep");
+            Scribe_Values.Look(ref unique, "unique");
             Scribe_Values.Look(ref iconPath, "iconPath");
         }
 
@@ -28,6 +31,9 @@ namespace FactionColonies
         public List<string> applicableBiomes = new List<string>();
         public int upkeep;
         public string iconPath = "GUI/unrest";
+		public bool unique;
+        public List<string> requiredPolicies = new List<string>();
+		public List<string> requiredBuildings= new List<string>();
         public Texture2D iconLoaded;
         //public required research
 

--- a/Source/FactionColonies/settlements/FCEvent.cs
+++ b/Source/FactionColonies/settlements/FCEvent.cs
@@ -136,7 +136,21 @@ namespace FactionColonies
                                                 // if(cEvent.)
                                             }
                                         }
-
+										
+										//If techlevel is out of range.
+										if (Find.World.GetComponent<FactionFC>().techLevel < cEvent.minTechlevel || Find.World.GetComponent<FactionFC>().techLevel > cEvent.maxTechlevel )
+										{
+											return false;
+										}
+										
+										//If player faction does not have all needed policies.
+										List<String> checkpolicies = Find.World.GetComponent<FactionFC>().policies.ConvertAll(policy => policy.def.defName);
+										foreach (string policycheck in cEvent.requiredPolicies) {
+											if (!checkpolicies.Contains(policycheck))
+											{
+												return false;
+											}
+										}
                                         //else if compatible
                                         return true;
                                     }
@@ -769,6 +783,7 @@ namespace FactionColonies
             Scribe_Values.Look(ref splitEventChance, "splitEventChance");
             Scribe_Values.Look(ref optionDescription, "optionDescription");
             Scribe_Collections.Look(ref applicableBiomes, "applicableBiomes", LookMode.Value);
+            Scribe_Collections.Look(ref requiredPolicies, "requiredPolicies", LookMode.Value);
             Scribe_Collections.Look(ref loot, "loot", LookMode.Def);
             Scribe_Values.Look(ref classToRun, "classToRun");
             Scribe_Values.Look(ref classMethodToRun, "classMethodToRun");
@@ -816,6 +831,8 @@ namespace FactionColonies
         public int maximumUnrest = 100;
         public int minimumProsperity;
         public int maximumProsperity = 100;
+        public TechLevel minTechLevel = TechLevel.Neolithic;
+        public TechLevel maxTechLevel = TechLevel.Archotech;
         public List<FCOptionDef> options = new List<FCOptionDef>();
         public string requiredResource = "";
         public int randomThingValue;
@@ -829,6 +846,7 @@ namespace FactionColonies
         public int splitEventChance = 50;
         public string optionDescription = "";
         public List<string> applicableBiomes = new List<string>();
+        public List<string> requiredPolicies = new List<string>();
         public List<ThingDef> loot = new List<ThingDef>();
         public string classToRun = "";
         public string classMethodToRun = "";
@@ -905,8 +923,11 @@ namespace FactionColonies
         public int splitEventChance = 50;
         public string optionDescription = "";
         public List<string> applicableBiomes = new List<string>();
+        public List<string> requiredPolicies = new List<string>();
         public List<ThingDef> loot = new List<ThingDef>();
         public bool hasCustomDescription = false;
+        public TechLevel minTechLevel = TechLevel.Neolithic;
+        public TechLevel maxTechLevel = TechLevel.Archotech;		
         public string customDescription = "";
         public string classToRun;
         public string classMethodToRun;

--- a/Source/FactionColonies/settlements/FCEvent.cs
+++ b/Source/FactionColonies/settlements/FCEvent.cs
@@ -136,21 +136,7 @@ namespace FactionColonies
                                                 // if(cEvent.)
                                             }
                                         }
-										
-										//If techlevel is out of range.
-										if (Find.World.GetComponent<FactionFC>().techLevel < cEvent.minTechlevel || Find.World.GetComponent<FactionFC>().techLevel > cEvent.maxTechlevel )
-										{
-											return false;
-										}
-										
-										//If player faction does not have all needed policies.
-										List<String> checkpolicies = Find.World.GetComponent<FactionFC>().policies.ConvertAll(policy => policy.def.defName);
-										foreach (string policycheck in cEvent.requiredPolicies) {
-											if (!checkpolicies.Contains(policycheck))
-											{
-												return false;
-											}
-										}
+
                                         //else if compatible
                                         return true;
                                     }
@@ -783,7 +769,6 @@ namespace FactionColonies
             Scribe_Values.Look(ref splitEventChance, "splitEventChance");
             Scribe_Values.Look(ref optionDescription, "optionDescription");
             Scribe_Collections.Look(ref applicableBiomes, "applicableBiomes", LookMode.Value);
-            Scribe_Collections.Look(ref requiredPolicies, "requiredPolicies", LookMode.Value);
             Scribe_Collections.Look(ref loot, "loot", LookMode.Def);
             Scribe_Values.Look(ref classToRun, "classToRun");
             Scribe_Values.Look(ref classMethodToRun, "classMethodToRun");
@@ -831,8 +816,6 @@ namespace FactionColonies
         public int maximumUnrest = 100;
         public int minimumProsperity;
         public int maximumProsperity = 100;
-        public TechLevel minTechLevel = TechLevel.Neolithic;
-        public TechLevel maxTechLevel = TechLevel.Archotech;
         public List<FCOptionDef> options = new List<FCOptionDef>();
         public string requiredResource = "";
         public int randomThingValue;
@@ -846,7 +829,6 @@ namespace FactionColonies
         public int splitEventChance = 50;
         public string optionDescription = "";
         public List<string> applicableBiomes = new List<string>();
-        public List<string> requiredPolicies = new List<string>();
         public List<ThingDef> loot = new List<ThingDef>();
         public string classToRun = "";
         public string classMethodToRun = "";
@@ -923,11 +905,8 @@ namespace FactionColonies
         public int splitEventChance = 50;
         public string optionDescription = "";
         public List<string> applicableBiomes = new List<string>();
-        public List<string> requiredPolicies = new List<string>();
         public List<ThingDef> loot = new List<ThingDef>();
         public bool hasCustomDescription = false;
-        public TechLevel minTechLevel = TechLevel.Neolithic;
-        public TechLevel maxTechLevel = TechLevel.Archotech;		
         public string customDescription = "";
         public string classToRun;
         public string classMethodToRun;

--- a/Source/FactionColonies/windows/FCBuildingWindow.cs
+++ b/Source/FactionColonies/windows/FCBuildingWindow.cs
@@ -173,50 +173,16 @@ namespace FactionColonies
             {
                 if(building.defName != "Empty" && building.defName != "Construction")
                 {
-					//If not a building that shouldn't appear on the list
-					bool unique_used = false;
-					if (building.unique)
-					{
-						foreach (SettlementFC checkunique in factionfc.settlements)
-						{
-							foreach (BuildingFC checkunique_building in checkunique.buildings)
-							{
-								if (checkunique_building.def.defName == building.def.defName) {unique_used = true;}
-							}
-						}
-					}
-						if (building.techLevel <= factionfc.techLevel && !unique_used)
-						{
-							//If building techlevel requirement is met, AND the building is not unique and already built
-							if (building.applicableBiomes.Count == 0 || building.applicableBiomes.Any() 
-								&& building.applicableBiomes.Contains(settlement.biome)){
-								//If building meets the biome requirements
-									bool valid = true;
-									List<String> policies = factionfc.policies.ConvertAll(policy => policy.def.defName);
-									foreach (string checkpolicy in building.requiredPolicies){
-										if (!policies.Contains(checkpolicy)) {
-											valid = false;
-										}
-										//If faction meets ALL policy requirements. Just one unmet condition sets valid to false.
-									}
-									if (valid) {
-										List<String> buildings = settlement.buildings.ConvertAll(building => building.def.defName);
-										bool validbuilding = true;
-										foreach (string checkreqbuilds in building.requiredBuildings){
-											if (!buildings.Contains(checkreqbuilds)) {
-												validbuilding = false;
-											}
-											// If ALL required buildings are present. Just one unmet condition sets validbuilding to false.
-											if (validbuilding) {
-												buildingList.Add(building);	
-											}
-										}
-									}
-								}
-								
-							}
-						}
-					
+                    //If not a building that shouldn't appear on the list
+                    if (building.techLevel <= factionfc.techLevel)
+                    {
+                        //If building techlevel requirement is met
+                        if (building.applicableBiomes.Count == 0 || building.applicableBiomes.Any() 
+                            && building.applicableBiomes.Contains(settlement.biome)){
+                            //If building meets the biome requirements
+                            buildingList.Add(building);
+                        }
+                    }
                 }
             }
 

--- a/Source/FactionColonies/windows/FCBuildingWindow.cs
+++ b/Source/FactionColonies/windows/FCBuildingWindow.cs
@@ -173,16 +173,50 @@ namespace FactionColonies
             {
                 if(building.defName != "Empty" && building.defName != "Construction")
                 {
-                    //If not a building that shouldn't appear on the list
-                    if (building.techLevel <= factionfc.techLevel)
-                    {
-                        //If building techlevel requirement is met
-                        if (building.applicableBiomes.Count == 0 || building.applicableBiomes.Any() 
-                            && building.applicableBiomes.Contains(settlement.biome)){
-                            //If building meets the biome requirements
-                            buildingList.Add(building);
-                        }
-                    }
+					//If not a building that shouldn't appear on the list
+					bool unique_used = false;
+					if (building.unique)
+					{
+						foreach (SettlementFC checkunique in factionfc.settlements)
+						{
+							foreach (BuildingFC checkunique_building in checkunique.buildings)
+							{
+								if (checkunique_building.def.defName == building.def.defName) {unique_used = true;}
+							}
+						}
+					}
+						if (building.techLevel <= factionfc.techLevel && !unique_used)
+						{
+							//If building techlevel requirement is met, AND the building is not unique and already built
+							if (building.applicableBiomes.Count == 0 || building.applicableBiomes.Any() 
+								&& building.applicableBiomes.Contains(settlement.biome)){
+								//If building meets the biome requirements
+									bool valid = true;
+									List<String> policies = factionfc.policies.ConvertAll(policy => policy.def.defName);
+									foreach (string checkpolicy in building.requiredPolicies){
+										if (!policies.Contains(checkpolicy)) {
+											valid = false;
+										}
+										//If faction meets ALL policy requirements. Just one unmet condition sets valid to false.
+									}
+									if (valid) {
+										List<String> buildings = settlement.buildings.ConvertAll(building => building.def.defName);
+										bool validbuilding = true;
+										foreach (string checkreqbuilds in building.requiredBuildings){
+											if (!buildings.Contains(checkreqbuilds)) {
+												validbuilding = false;
+											}
+											// If ALL required buildings are present. Just one unmet condition sets validbuilding to false.
+											if (validbuilding) {
+												buildingList.Add(building);	
+											}
+										}
+									}
+								}
+								
+							}
+						}
+					
                 }
             }
 


### PR DESCRIPTION
Additional requirement options for Event/Building Defs.

Buildings can now be gated behind:
- The presence of other buildings.
- The presence of certain policies.
- A uniqueness boolean, which means the building can only be built once per faction.

Events can now be gated behind:
- The presence of certain policies.
- A maximum techlevel.
- A minimum techlevel.

As an example, using the new system, one could create events that ONLY fire for neolithic militarist civilisations.